### PR TITLE
EdgeLoopSelector - Optimization for edges 

### DIFF
--- a/Macros/EdgeLoopSelector/EdgeLoopSelector.py
+++ b/Macros/EdgeLoopSelector/EdgeLoopSelector.py
@@ -291,9 +291,6 @@ def select_connected_loop_or_sketch():
             FreeCAD.Console.PrintError("Error: Selected edges are not coplanar.\n")
             return
 
-    # Find all unique loops containing selected edges on coplanar faces
-    unique_loop_sets = []
-
     selected_edges_hash = {e.hashCode() for e in selected_edge_objects}
 
     # Find parent faces that contain this edge
@@ -344,7 +341,7 @@ def select_connected_loop_or_sketch():
     selectEdges(obj, all_edges_to_select)
 
     FreeCAD.Console.PrintMessage(
-        f"Selected {len(all_edges_to_select)} edges from {len(unique_loop_sets)} loop(s).\n"
+        f"Selected {len(all_edges_to_select)} edges.\n"
     )
 
 # --- Run the macro ---


### PR DESCRIPTION
There is some optimization for edges selection

In attached example selected 1092 edges
On my old laptop time decreased from 12.3 to 0.9 sec

[board_back.zip](https://github.com/user-attachments/files/24597750/board_back.zip)

![Screenshot_20260113_085559](https://github.com/user-attachments/assets/0605743a-1867-46e5-a89f-6b099329a5d0)
